### PR TITLE
Update egui version from 0.30 to 0.32 and from 0.32 to 0.33

### DIFF
--- a/egui_node_graph2/Cargo.toml
+++ b/egui_node_graph2/Cargo.toml
@@ -14,7 +14,7 @@ workspace = ".."
 persistence = ["serde", "slotmap/serde", "smallvec/serde", "egui/persistence"]
 
 [dependencies]
-egui = "0.32"
+egui = "0.33"
 slotmap = { version = "1.0" }
 smallvec = { version = "1.10.0" }
 serde = { version = "1.0", optional = true, features = ["derive"] }

--- a/egui_node_graph2/Cargo.toml
+++ b/egui_node_graph2/Cargo.toml
@@ -14,7 +14,7 @@ workspace = ".."
 persistence = ["serde", "slotmap/serde", "smallvec/serde", "egui/persistence"]
 
 [dependencies]
-egui = "0.30"
+egui = "0.32"
 slotmap = { version = "1.0" }
 smallvec = { version = "1.10.0" }
 serde = { version = "1.0", optional = true, features = ["derive"] }

--- a/egui_node_graph2/src/graph_impls.rs
+++ b/egui_node_graph2/src/graph_impls.rs
@@ -241,14 +241,14 @@ impl<NodeData> Node<NodeData> {
     pub fn inputs<'a, DataType, DataValue>(
         &'a self,
         graph: &'a Graph<NodeData, DataType, DataValue>,
-    ) -> impl Iterator<Item = &InputParam<DataType, DataValue>> + 'a {
+    ) -> impl Iterator<Item = &'a InputParam<DataType, DataValue>> + 'a {
         self.input_ids().map(|id| graph.get_input(id))
     }
 
     pub fn outputs<'a, DataType, DataValue>(
         &'a self,
         graph: &'a Graph<NodeData, DataType, DataValue>,
-    ) -> impl Iterator<Item = &OutputParam<DataType>> + 'a {
+    ) -> impl Iterator<Item = &'a OutputParam<DataType>> + 'a {
         self.output_ids().map(|id| graph.get_output(id))
     }
 

--- a/egui_node_graph2/src/node_finder.rs
+++ b/egui_node_graph2/src/node_finder.rs
@@ -68,7 +68,7 @@ where
 
                 let mut query_submit = resp.lost_focus() && ui.input(|i| i.key_pressed(Key::Enter));
 
-                let max_height = ui.input(|i| i.screen_rect.height() * 0.5);
+                let max_height = ui.input(|i| i.content_rect().height() * 0.5);
                 let scroll_area_width = resp.rect.width() - 30.0;
 
                 let all_kinds = all_kinds.all_kinds();

--- a/egui_node_graph2/src/scale.rs
+++ b/egui_node_graph2/src/scale.rs
@@ -1,5 +1,5 @@
 use egui::epaint::Shadow;
-use egui::{style::WidgetVisuals, Margin, Rounding, Stroke, Style, Vec2};
+use egui::{style::WidgetVisuals, CornerRadius, Margin, Stroke, Style, Vec2};
 
 // Copied from https://github.com/gzp-crey/shine
 
@@ -25,19 +25,35 @@ impl Scale for Vec2 {
 
 impl Scale for Margin {
     fn scale(&mut self, amount: f32) {
-        self.left *= amount;
-        self.right *= amount;
-        self.top *= amount;
-        self.bottom *= amount;
+        self.left = (self.left as f32 * amount)
+            .round()
+            .clamp(i8::MIN as f32, i8::MAX as f32) as i8;
+        self.right = (self.right as f32 * amount)
+            .round()
+            .clamp(i8::MIN as f32, i8::MAX as f32) as i8;
+        self.top = (self.top as f32 * amount)
+            .round()
+            .clamp(i8::MIN as f32, i8::MAX as f32) as i8;
+        self.bottom = (self.bottom as f32 * amount)
+            .round()
+            .clamp(i8::MIN as f32, i8::MAX as f32) as i8;
     }
 }
 
-impl Scale for Rounding {
+impl Scale for CornerRadius {
     fn scale(&mut self, amount: f32) {
-        self.ne *= amount;
-        self.nw *= amount;
-        self.se *= amount;
-        self.sw *= amount;
+        self.ne = (self.ne as f32 * amount)
+            .round()
+            .clamp(0f32, u8::MAX as f32) as u8;
+        self.nw = (self.nw as f32 * amount)
+            .round()
+            .clamp(0f32, u8::MAX as f32) as u8;
+        self.se = (self.se as f32 * amount)
+            .round()
+            .clamp(0f32, u8::MAX as f32) as u8;
+        self.sw = (self.sw as f32 * amount)
+            .round()
+            .clamp(0f32, u8::MAX as f32) as u8;
     }
 }
 
@@ -49,7 +65,7 @@ impl Scale for Stroke {
 
 impl Scale for Shadow {
     fn scale(&mut self, amount: f32) {
-        self.spread *= amount.clamp(0.4, 1.);
+        self.spread = (self.spread as f32 * amount.clamp(0.4, 1.)) as u8;
     }
 }
 
@@ -57,7 +73,7 @@ impl Scale for WidgetVisuals {
     fn scale(&mut self, amount: f32) {
         self.bg_stroke.scale(amount);
         self.fg_stroke.scale(amount);
-        self.rounding.scale(amount);
+        self.corner_radius.scale(amount);
         self.expansion *= amount.clamp(0.4, 1.);
     }
 }
@@ -102,7 +118,7 @@ impl Scale for Style {
         self.visuals.resize_corner_size *= amount;
         self.visuals.text_cursor.stroke.width *= amount;
         self.visuals.clip_rect_margin *= amount;
-        self.visuals.window_rounding.scale(amount);
+        self.visuals.window_corner_radius.scale(amount);
         self.visuals.window_shadow.scale(amount);
         self.visuals.popup_shadow.scale(amount);
     }

--- a/egui_node_graph2/src/traits.rs
+++ b/egui_node_graph2/src/traits.rs
@@ -84,7 +84,7 @@ pub trait DataTypeTrait<UserState>: PartialEq + Eq {
     ///     }
     /// }
     /// ```
-    fn name(&self) -> std::borrow::Cow<str>;
+    fn name(&'_ self) -> std::borrow::Cow<'_, str>;
 }
 
 /// This trait must be implemented for the `NodeData` generic parameter of the
@@ -251,7 +251,7 @@ pub trait NodeTemplateTrait: Clone {
     /// The return type is Cow<str> to allow returning owned or borrowed values
     /// more flexibly. Refer to the documentation for `DataTypeTrait::name` for
     /// more information
-    fn node_finder_label(&self, user_state: &mut Self::UserState) -> std::borrow::Cow<str>;
+    fn node_finder_label(&'_ self, user_state: &mut Self::UserState) -> std::borrow::Cow<'_, str>;
 
     /// Vec of categories to which the node belongs.
     ///

--- a/egui_node_graph2_example/Cargo.toml
+++ b/egui_node_graph2_example/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.56"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-eframe = "0.32"
+eframe = "0.33"
 egui_node_graph2 = { path = "../egui_node_graph2" }
 anyhow = "1.0"
 serde = { version = "1.0", optional = true }

--- a/egui_node_graph2_example/Cargo.toml
+++ b/egui_node_graph2_example/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.56"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-eframe = "0.30"
+eframe = "0.32"
 egui_node_graph2 = { path = "../egui_node_graph2" }
 anyhow = "1.0"
 serde = { version = "1.0", optional = true }

--- a/egui_node_graph2_example/src/app.rs
+++ b/egui_node_graph2_example/src/app.rs
@@ -411,8 +411,8 @@ impl eframe::App for NodeGraphExample {
     /// Put your widgets into a `SidePanel`, `TopPanel`, `CentralPanel`, `Window` or `Area`.
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
         egui::TopBottomPanel::top("top").show(ctx, |ui| {
-            egui::menu::bar(ui, |ui| {
-                egui::widgets::global_dark_light_mode_switch(ui);
+            egui::MenuBar::new().ui(ui, |ui| {
+                egui::widgets::global_theme_preference_switch(ui);
             });
         });
         let graph_response = egui::CentralPanel::default()


### PR DESCRIPTION
I'm proposing to merge this two commits to update the egui versions, I also took the liberty to fix some warning popping up at compile. 

I would ask to make two versions of `egui_node_graph2` one to support egui 0.32 and one for egui 0.33 since there are other libraries not yet updated to 0.33 but updated to 0.32